### PR TITLE
AppContext: Override connection info with query string params

### DIFF
--- a/src/contexts/AppContext.js
+++ b/src/contexts/AppContext.js
@@ -1,5 +1,6 @@
 import React, {createContext, useReducer, useEffect} from 'react';
 import { appReducer } from '../reducers/appReducer';
+import jssip from "jssip";
 
 export const {Provider, Consumer} = createContext();
 
@@ -23,8 +24,56 @@ const baseState = {
 const AppProvider = (props) => {
 
     const [state, dispatch] = useReducer(appReducer, {}, () => {
-        const localData = localStorage.getItem('app');
-        return localData ? {...baseState, ...JSON.parse(localData)} : baseState;
+        const appString = localStorage.getItem('app');
+        let localData;
+
+        if (appString) {
+            localData = JSON.parse(appString);
+        } else {
+            localData = {};
+        }
+
+        /*
+         * Override connection properties with those specified in the query
+         * string (if any) and default the SIP and websocket URIs.
+         */
+
+        let params = {...baseState, ...localData};
+
+        let queryParams = new URLSearchParams(window.location.search);
+        queryParams.forEach((value, key) => {
+            if (key in baseState) {
+                params[key] = value;
+            }
+        });
+
+        if (!params.sipUri) {
+            params.sipUri = window.location.hostname;
+        }
+
+        if (!params.sipUri.match(/sip[s]*:/)) {
+            params.sipUri = "sip:" + params.sipUri;
+        }
+
+        let sipUri = jssip.URI.parse(params.sipUri);
+        if (!sipUri) {
+            throw new Error("Invalid sipUri: " + params.sipUri);
+        }
+
+        if (!sipUri.user) {
+            sipUri.user = queryParams.get("user");
+        }
+        if (!sipUri.port) {
+            sipUri.port = 5061;
+        }
+
+        params.sipUri = sipUri.toString();
+
+        if (!params.serverWssUri) {
+            params.serverWssUri = "wss://" + sipUri.host + ":8089/ws";
+        }
+
+        return params;
     });
 
     useEffect(() => {


### PR DESCRIPTION
Also allow defaulting of sip and websocket server uris.

You can now use query string parameters to directly enter a room.
For example:
https://my-dana-server/video/myroom? \
   name=Dana \
   &sipUri=myaccountname@myasterisk:5061 \
   &serverWssUri=wss://myasterisk:8089/ws \
   &password=mypassword

If "sipUri" is missing from the query string and "user" is present,
"sipUri" will default to sane TLS values where "hostname" is the
hostname component of the web page URL.  {user}@{hostname}:5061

Example:
https://my-dana-server/video/myroom?name=Dana&user=myaccountname
would result in a sipUri of "myaccountname@my-dana-server:5061".

If "serverWssUri" is missing from the query string, it will default
to sane Asterisk values where "hostname" is the hostname
component of the sipUri.  wss://{hostname}:8089/ws