### PR TITLE
SipClient/SipSession: Add ability to send and receive SIP MESSAGE messages

### DIFF
--- a/src/lib/SipClient.js
+++ b/src/lib/SipClient.js
@@ -45,6 +45,25 @@ export default class SipClient extends events.EventEmitter {
 
             this._onSession(rtcSession);
         });
+
+        this._ua.on('newMessage', (data) => {
+            if (data.originator === 'local') {
+                return;
+            }
+            let ct = data.request.headers['Content-Type'][0].raw;
+            if (ct === 'application/x-asterisk-confbridge-event+json') {
+                let msg = JSON.parse(data.request.body);
+                if (msg.type === 'ConfbridgeWelcome') {
+                    this.emit('participantWelcomeReceived', msg);
+                } else {
+                    this.emit('participantInfoReceived', msg);
+                }
+            } else if (ct === 'application/x-asterisk-confbridge-chat+json') {
+                let msg = JSON.parse(data.request.body);
+                this.emit('messageReceived', msg);
+            }
+        });
+
     }
 
     get name() {

--- a/src/lib/SipSession.js
+++ b/src/lib/SipSession.js
@@ -229,4 +229,21 @@ export default class SipSession extends events.EventEmitter {
 	unmute() {
 		this._rtcSession.unmute({ audio: true, video: true });
 	}
+
+    sendMessage(from, string_msg, handlers) {
+        logger.debug("sendMessage() %s", string_msg);
+
+        let msg = {
+                'From': from,
+                'Content-Type': 'application/x-asterisk-confbridge-chat+json',
+                'Body': string_msg
+        };
+        let body = JSON.stringify(msg);
+        let extraHeaders = [ 'Content-Type: application/x-asterisk-confbridge-chat+json' ];
+        this._rtcSession.sendRequest(jssip.C.MESSAGE, {
+            extraHeaders,
+            body: body,
+            eventHandlers: handlers
+        });
+    }
 }


### PR DESCRIPTION
SipClient will now emit the following events:

  Generated when a SIP MESSAGE arrives with the following content type:
  application/x-asterisk-confbridge-event+json

 * participantWelcomeReceived: When this user successfully joins this
   event will be emitted and will have a list of all existing
   participants.  Same as the ConfbridgeWelcome AMI event.

 * participantInfoReceived: All other normal Confbridge AMI events
   will cause this event to be emitted.  Join, Leave, Talking, etc.

  Generated when a SIP MESSAGE arrives with the following content type:
  application/x-asterisk-confbridge-chat+json

 * messageReceived: Emitted when a chat message is received.

A new sendMessage() method has been added to SipSession.
Messages are sent to the confbridge and relayed to all participants.
The handlers are those called by jssip's rtcSession.sendRequest.

session.sendMessage(from_display_name, string_message, handlers);

Sample:

    session.sendMessage("Alice", "dfgsdfgsdgsdgsdgfsdgfsdg", {

        // Possible handlers.  You only need to implement the ones
        // you care about

        onSuccessResponse(response) {
            // You may want to show an indicator that the message was
            // sent successfully.
            console.log("Message Sent: " + response);
        },
        onErrorResponse(response) {
            console.log("Message ERROR: " + response);
        },
        onTransportError() {
            console.log("Could not send message");
        },
        onRequestTimeout() {
            console.log("Timeout sending message");
        },
        onDialogError() {
            console.log("Dialog Error sending message");
        },
    });